### PR TITLE
Add Skelux's Impossible Mode Cheat Code as an Optional Patch

### DIFF
--- a/bis.asm
+++ b/bis.asm
@@ -11,7 +11,7 @@ OVERLAY141_ADDRESS equ HEAP0_ARENA_HI
 .open "bis-data/arm9.dec.bin", 0x02004000
 
 .ifdef F_NO_MUSIC
-.org 0x020068CC
+.org 0x02006484
   mov r4, 0
 .endif
 

--- a/bis.asm
+++ b/bis.asm
@@ -9,12 +9,6 @@ OVERLAY141_ADDRESS equ HEAP0_ARENA_HI
 
 
 .open "bis-data/arm9.dec.bin", 0x02004000
-
-.ifdef F_NO_MUSIC
-.org 0x02006484
-  mov r0, 0
-.endif
-
 .org 0x020058BC
 getScriptVar:
 .org 0x02005A78

--- a/bis.asm
+++ b/bis.asm
@@ -198,16 +198,22 @@ AddItemsInjection:
 .ifdef F_IMPOSSIBLE_MODE
 ImpossibleMode:
   mov r3, r3, lsl #0x9
-  ldr r12, =0x0210a470
+  ldr r12, =impossible_mode_address_0
   cmp r4, r12
   beq ImpossibleModeExit
-  ldr r12, =0x0210a634
+  ldr r12, =impossible_mode_address_1
   cmp r4, r12
   beq ImpossibleModeExit
-  ldr r12, =0x0210a7F8
+  ldr r12, =impossible_mode_address_2
   cmp r4, r12
   beq ImpossibleModeExit
   mov r3, r3, lsl #0x1
+impossible_mode_address_0:
+  .word 0210a470
+impossible_mode_address_1:
+  .word 0210a634
+impossible_mode_address_2:
+  .word 0210a7F8
 ImpossibleModeExit:
   b 0x0208A370
 .endif

--- a/bis.asm
+++ b/bis.asm
@@ -67,6 +67,14 @@ PostLoadOverlay141Injection:
 .close
 
 
+.open "bis-data/overlay.dec/overlay_0013.dec.bin", 0x0208A240
+.ifdef F_IMPOSSIBLE_MODE
+.org 0x0208A36C
+  b ImpossibleMode
+.endif
+.close
+
+
 .open "bis-data/overlay.dec/overlay_0122.dec.bin", 0x02069820
 .ifdef F_CUSTOM_ITEM_TYPES
 .org 0x0206D668
@@ -184,6 +192,23 @@ GetNonBadgeItemAmountInjection:
 AddItemsInjection:
   bl  add_custom_items
   pop {r3, pc}
+.endif
+
+.ifdef F_IMPOSSIBLE_MODE
+ImpossibleMode:
+  mov r3, r3, lsl #0x9
+  ldr r12, =0x0210a470
+  cmp r4, r12
+  beq ImpossibleModeExit
+  ldr r12, =0x0210a634
+  cmp r4, r12
+  beq ImpossibleModeExit
+  ldr r12, =0x0210a7F8
+  cmp r4, r12
+  beq ImpossibleModeExit
+  mov r3, r3, lsl #0x1
+ImpossibleModeExit:
+  b 0x0208A370
 .endif
 
 .importobj "rust/target/armv5te-none-eabi/" + PROFILE + "/bis"

--- a/bis.asm
+++ b/bis.asm
@@ -194,6 +194,7 @@ AddItemsInjection:
   pop {r3, pc}
 .endif
 
+; most of the following code is just an adaptation of skelux's AR code
 .ifdef F_IMPOSSIBLE_MODE
 ImpossibleMode:
   mov r3, r3, lsl #0x9

--- a/bis.asm
+++ b/bis.asm
@@ -9,6 +9,12 @@ OVERLAY141_ADDRESS equ HEAP0_ARENA_HI
 
 
 .open "bis-data/arm9.dec.bin", 0x02004000
+
+.ifdef F_NO_MUSIC
+.org 0x020068CC
+  mov r4, 0
+.endif
+
 .org 0x020058BC
 getScriptVar:
 .org 0x02005A78

--- a/bis.asm
+++ b/bis.asm
@@ -196,9 +196,6 @@ AddItemsInjection:
 
 ; most of the following code is just an adaptation of skelux's AR code
 .ifdef F_IMPOSSIBLE_MODE
-; impossible_mode_address_0: .word 0x0210A470
-; impossible_mode_address_1: .word 0x0210A634
-; impossible_mode_address_2: .word 0x0210A7F8
 ImpossibleMode:
   mov r3, r3, lsl #0x9
   ldr r12, =0x0210A470

--- a/bis.asm
+++ b/bis.asm
@@ -208,12 +208,9 @@ ImpossibleMode:
   cmp r4, r12
   beq ImpossibleModeExit
   mov r3, r3, lsl #0x1
-impossible_mode_address_0:
-  .word 0210a470
-impossible_mode_address_1:
-  .word 0210a634
-impossible_mode_address_2:
-  .word 0210a7F8
+impossible_mode_address_0: .word 0x0210A470
+impossible_mode_address_1: .word 0x0210A634
+impossible_mode_address_2: .word 0x0210A7F8
 ImpossibleModeExit:
   b 0x0208A370
 .endif

--- a/bis.asm
+++ b/bis.asm
@@ -196,6 +196,9 @@ AddItemsInjection:
 
 ; most of the following code is just an adaptation of skelux's AR code
 .ifdef F_IMPOSSIBLE_MODE
+impossible_mode_address_0: .word 0x0210A470
+impossible_mode_address_1: .word 0x0210A634
+impossible_mode_address_2: .word 0x0210A7F8
 ImpossibleMode:
   mov r3, r3, lsl #0x9
   ldr r12, =impossible_mode_address_0
@@ -208,9 +211,6 @@ ImpossibleMode:
   cmp r4, r12
   beq ImpossibleModeExit
   mov r3, r3, lsl #0x1
-impossible_mode_address_0: .word 0x0210A470
-impossible_mode_address_1: .word 0x0210A634
-impossible_mode_address_2: .word 0x0210A7F8
 ImpossibleModeExit:
   b 0x0208A370
 .endif

--- a/bis.asm
+++ b/bis.asm
@@ -12,7 +12,7 @@ OVERLAY141_ADDRESS equ HEAP0_ARENA_HI
 
 .ifdef F_NO_MUSIC
 .org 0x02006484
-  mov r4, 0
+  mov r0, 0
 .endif
 
 .org 0x020058BC

--- a/bis.asm
+++ b/bis.asm
@@ -196,21 +196,22 @@ AddItemsInjection:
 
 ; most of the following code is just an adaptation of skelux's AR code
 .ifdef F_IMPOSSIBLE_MODE
-impossible_mode_address_0: .word 0x0210A470
-impossible_mode_address_1: .word 0x0210A634
-impossible_mode_address_2: .word 0x0210A7F8
+; impossible_mode_address_0: .word 0x0210A470
+; impossible_mode_address_1: .word 0x0210A634
+; impossible_mode_address_2: .word 0x0210A7F8
 ImpossibleMode:
   mov r3, r3, lsl #0x9
-  ldr r12, =impossible_mode_address_0
+  ldr r12, =0x0210A470
   cmp r4, r12
   beq ImpossibleModeExit
-  ldr r12, =impossible_mode_address_1
+  ldr r12, =0x0210A634
   cmp r4, r12
   beq ImpossibleModeExit
-  ldr r12, =impossible_mode_address_2
+  ldr r12, =0x0210A7F8
   cmp r4, r12
   beq ImpossibleModeExit
   mov r3, r3, lsl #0x1
+  .pool
 ImpossibleModeExit:
   b 0x0208A370
 .endif


### PR DESCRIPTION
Adapts Skelux's old "IMPOSSIBLE MODE" AR code to the armips patcher.
The new flag name is "F_IMPOSSIBLE_MODE"